### PR TITLE
New Eleventy Generator

### DIFF
--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -8,7 +8,7 @@
   <meta name="description" content="{{ description or site.description }}">
   <meta name="author" content="{{ site.author }}">
   <meta name="keywords" content="{% set keywords = tags or site.keywords %}{% for tag in keywords %}{{ tag }}{% if not loop.last %}, {% endif %}{% endfor %}">
-  <meta name="generator" content="Eleventy v3.0.0">
+  <meta name="generator" content="{{ eleventy.generator }}">
   <link rel="manifest" href="/manifest.json">
   <meta name="theme-color" content="#ffffff" />
   <link rel="icon" type="image/png" sizes="32x32" href="/favicon/ios/32.png">


### PR DESCRIPTION
A simple change to have Eleventy herself create the most up to date meta name="generator" in the head-element of the base.njk on build. If you wish, you can see it in action here: [Vermont Beer Trail](https://www.vtbeertrail.com/)